### PR TITLE
Float cache refactor

### DIFF
--- a/extension/chrome/js/background_scripts/background.js
+++ b/extension/chrome/js/background_scripts/background.js
@@ -39,6 +39,16 @@ chrome.runtime.onInstalled.addListener((details) =>{
             } }
         });
 
+        // moves float cache from under a single storage key to individual keys TODO: remove these lines after a few new versions
+        chrome.storage.local.get('floatCache', (result) =>{
+            if (result.floatCache !== undefined && result.floatCache !== null) {
+                for (let assetID in result.floatCache) {
+                    chrome.storage.local.set({[`floatCache_${assetID}`]: result.floatCache[assetID]}, () => {});
+                }
+                chrome.storage.local.remove('floatCache', () => {});
+            }
+        });
+
         trackEvent({
             type:'event',
             action: 'ExtensionUpdate'
@@ -71,7 +81,6 @@ chrome.runtime.onInstalled.addListener((details) =>{
     // updates the prices and exchange rates - retries periodically if it's the first time (on install) and it fails to update prices/exchange rates
     updatePrices();
     updateExchangeRates();
-    trimFloatCache();
     chrome.alarms.create('updatePricesAndExchangeRates', {periodInMinutes: 1440});
     chrome.alarms.create('retryUpdatePricesAndExchangeRates', {periodInMinutes: 1});
     chrome.alarms.create('trimFloatCache', {periodInMinutes: 1440});

--- a/extension/chrome/js/background_scripts/messaging.js
+++ b/extension/chrome/js/background_scripts/messaging.js
@@ -245,8 +245,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         });
         return true; // async return to signal that it will return later
     }
-    else if (request.getFloatInfo !== undefined) {
-        let inspectLink = request.getFloatInfo;
+    else if (request.fetchFloatInfo !== undefined) {
+        let inspectLink = request.fetchFloatInfo;
         if (inspectLink !== null) {
             let assetID = getAssetIDFromInspectLink(inspectLink);
             let getRequest = new Request(`https://api.csgofloat.com/?url=${inspectLink}`);

--- a/extension/chrome/js/background_scripts/messaging.js
+++ b/extension/chrome/js/background_scripts/messaging.js
@@ -1,6 +1,6 @@
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (request.inventory !== undefined) {
-        chrome.storage.local.get(['itemPricing', 'prices', 'currency', 'exchangeRate', 'pricingProvider', 'floatCache'], (result) => {
+        chrome.storage.local.get(['itemPricing', 'prices', 'currency', 'exchangeRate', 'pricingProvider'], (result) => {
             let prices = result.prices;
             let steamID = request.inventory;
 
@@ -24,6 +24,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
                 // counts duplicates
                 for (let asset in ids) {
                     let assetid = ids[asset].id;
+                    floatCacheAssetIDs.push(assetid);
 
                     for (let item in items) {
                         if (ids[asset].classid === items[item].classid && ids[asset].instanceid === items[item].instanceid) {
@@ -43,97 +44,100 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
                         }
                     }
                 }
-                for (let asset in ids) {
-                    let assetid = ids[asset].id;
-                    let position = ids[asset].pos;
+                getFloatInfoFromCache(floatCacheAssetIDs).then(
+                    floatCache => {
+                        for (let asset in ids) {
+                            let assetid = ids[asset].id;
+                            let position = ids[asset].pos;
 
-                    for (let item in items) {
-                        if (ids[asset].classid === items[item].classid && ids[asset].instanceid === items[item].instanceid) {
-                            let name = items[item].name;
-                            let market_hash_name = items[item].market_hash_name;
-                            let name_color = items[item].name_color;
-                            let marketlink = `https://steamcommunity.com/market/listings/730/${items[item].market_hash_name}`;
-                            let classid = items[item].classid;
-                            let instanceid = items[item].instanceid;
-                            let exterior = getExteriorFromTags(items[item].tags);
-                            let tradability = 'Tradable';
-                            let tradabilityShort = 'T';
-                            let icon = items[item].icon_url;
-                            let dopplerInfo = /Doppler/.test(items[item].name) ? getDopplerInfo(icon) : undefined;
-                            let isStatrack = /StatTrak™/.test(items[item].name);
-                            let isSouvenir = /Souvenir/.test(items[item].name);
-                            let starInName = /★/.test(items[item].name);
-                            let quality = getQuality(items[item].tags);
-                            let stickers =  parseStickerInfo(items[item].descriptions, 'direct');
-                            let nametag = undefined;
-                            let inspectLink = null;
-                            let owner = steamID;
-                            let price = null;
-                            let type = getType(items[item].tags);
-                            let floatInfo = null;
-                            if (result.floatCache[assetid] !== undefined && itemTypes[type.key].float) {
-                                floatInfo = result.floatCache[assetid].floatInfo;
-                                floatCacheAssetIDs.push(assetid);
-                            }
-                            let patternInfo = (floatInfo !== null) ? getPattern(market_hash_name, floatInfo.paintseed) : null;
+                            for (let item in items) {
+                                if (ids[asset].classid === items[item].classid && ids[asset].instanceid === items[item].instanceid) {
+                                    let name = items[item].name;
+                                    let market_hash_name = items[item].market_hash_name;
+                                    let name_color = items[item].name_color;
+                                    let marketlink = `https://steamcommunity.com/market/listings/730/${items[item].market_hash_name}`;
+                                    let classid = items[item].classid;
+                                    let instanceid = items[item].instanceid;
+                                    let exterior = getExteriorFromTags(items[item].tags);
+                                    let tradability = 'Tradable';
+                                    let tradabilityShort = 'T';
+                                    let icon = items[item].icon_url;
+                                    let dopplerInfo = /Doppler/.test(items[item].name) ? getDopplerInfo(icon) : undefined;
+                                    let isStatrack = /StatTrak™/.test(items[item].name);
+                                    let isSouvenir = /Souvenir/.test(items[item].name);
+                                    let starInName = /★/.test(items[item].name);
+                                    let quality = getQuality(items[item].tags);
+                                    let stickers =  parseStickerInfo(items[item].descriptions, 'direct');
+                                    let nametag = undefined;
+                                    let inspectLink = null;
+                                    let owner = steamID;
+                                    let price = null;
+                                    let type = getType(items[item].tags);
+                                    let floatInfo = null;
+                                    if (floatCache[assetid] !== undefined && floatCache[assetid] !== null && itemTypes[type.key].float) {
+                                        floatInfo = floatCache[assetid];
+                                    }
+                                    let patternInfo = (floatInfo !== null) ? getPattern(market_hash_name, floatInfo.paintseed) : null;
 
-                            if (result.itemPricing) price = getPrice(market_hash_name, dopplerInfo, prices, result.pricingProvider, result.exchangeRate, result.currency);
-                            else{price = {price: '', display: ''}}
+                                    if (result.itemPricing) price = getPrice(market_hash_name, dopplerInfo, prices, result.pricingProvider, result.exchangeRate, result.currency);
+                                    else{price = {price: '', display: ''}}
 
-                            try {if (items[item].fraudwarnings !== undefined || items[item].fraudwarnings[0] !== undefined) nametag = items[item].fraudwarnings[0].split('Name Tag: ')[1]}
-                            catch(error){}
+                                    try {if (items[item].fraudwarnings !== undefined || items[item].fraudwarnings[0] !== undefined) nametag = items[item].fraudwarnings[0].split('Name Tag: ')[1]}
+                                    catch(error){}
 
-                            if (items[item].tradable === 0) {
-                                tradability = items[item].cache_expiration;
-                                tradabilityShort = getShortDate(tradability);
-                            }
-                            if (items[item].marketable === 0) {
-                                tradability = 'Not Tradable';
-                                tradabilityShort = '';
-                            }
+                                    if (items[item].tradable === 0) {
+                                        tradability = items[item].cache_expiration;
+                                        tradabilityShort = getShortDate(tradability);
+                                    }
+                                    if (items[item].marketable === 0) {
+                                        tradability = 'Not Tradable';
+                                        tradabilityShort = '';
+                                    }
 
-                            try {
-                                if (items[item].actions !== undefined && items[item].actions[0] !== undefined){
-                                    let beggining = items[item].actions[0].link.split('%20S')[0];
-                                    let end = items[item].actions[0].link.split('%assetid%')[1];
-                                    inspectLink = (`${beggining}%20S${owner}A${assetid}${end}`);
+                                    try {
+                                        if (items[item].actions !== undefined && items[item].actions[0] !== undefined){
+                                            let beggining = items[item].actions[0].link.split('%20S')[0];
+                                            let end = items[item].actions[0].link.split('%assetid%')[1];
+                                            inspectLink = (`${beggining}%20S${owner}A${assetid}${end}`);
+                                        }
+                                    }
+                                    catch(error) {}
+
+                                    itemsPropertiesToReturn.push({
+                                        name: name,
+                                        market_hash_name: market_hash_name,
+                                        name_color: name_color,
+                                        marketlink: marketlink,
+                                        classid: classid,
+                                        instanceid: instanceid,
+                                        assetid: assetid,
+                                        position: position,
+                                        tradability: tradability,
+                                        tradabilityShort: tradabilityShort,
+                                        dopplerInfo: dopplerInfo,
+                                        exterior: exterior,
+                                        iconURL: icon,
+                                        inspectLink: inspectLink,
+                                        quality: quality,
+                                        isStatrack: isStatrack,
+                                        isSouvenir: isSouvenir,
+                                        starInName: starInName,
+                                        stickers: stickers,
+                                        nametag: nametag,
+                                        duplicates: duplicates[market_hash_name],
+                                        owner: owner,
+                                        price: price,
+                                        type: type,
+                                        floatInfo: floatInfo,
+                                        patternInfo: patternInfo
+                                    })
                                 }
                             }
-                            catch(error) {}
-
-                            itemsPropertiesToReturn.push({
-                                name: name,
-                                market_hash_name: market_hash_name,
-                                name_color: name_color,
-                                marketlink: marketlink,
-                                classid: classid,
-                                instanceid: instanceid,
-                                assetid: assetid,
-                                position: position,
-                                tradability: tradability,
-                                tradabilityShort: tradabilityShort,
-                                dopplerInfo: dopplerInfo,
-                                exterior: exterior,
-                                iconURL: icon,
-                                inspectLink: inspectLink,
-                                quality: quality,
-                                isStatrack: isStatrack,
-                                isSouvenir: isSouvenir,
-                                starInName: starInName,
-                                stickers: stickers,
-                                nametag: nametag,
-                                duplicates: duplicates[market_hash_name],
-                                owner: owner,
-                                price: price,
-                                type: type,
-                                floatInfo: floatInfo,
-                                patternInfo: patternInfo
-                            })
                         }
+                        sendResponse({inventory: itemsPropertiesToReturn.sort((a, b) => { return a.position - b.position})});
                     }
-                }
-                sendResponse({inventory: itemsPropertiesToReturn.sort((a, b) => { return a.position - b.position})});
-                updateFloatCache(floatCacheAssetIDs);
+                );
+
             }).catch(err => {
                 console.log(err);
                 sendResponse({inventory: 'error'});
@@ -152,24 +156,28 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         });
         return true;
     }
-    else if (request.addPricesToInventory !== undefined){
-        let inventory = request.addPricesToInventory;
-        chrome.storage.local.get(['prices', 'exchangeRate', 'currency', 'itemPricing', 'pricingProvider', 'floatCache'], (result) =>{
+    else if (request.addPricesAndFloatsToInventory !== undefined){
+        let inventory = request.addPricesAndFloatsToInventory;
+        chrome.storage.local.get(['prices', 'exchangeRate', 'currency', 'itemPricing', 'pricingProvider'], (result) =>{
             if (result.itemPricing){
                 let floatCacheAssetIDs = [];
-                inventory.forEach(item => {
-                    if (result.prices[item.market_hash_name] !== undefined && result.prices[item.market_hash_name] !== 'null'){
-                        item.price =  getPrice(item.market_hash_name, item.dopplerInfo, result.prices, result.pricingProvider, result.exchangeRate, result.currency);
+                inventory.forEach(item => {floatCacheAssetIDs.push(item.assetid)});
+                getFloatInfoFromCache(floatCacheAssetIDs).then(
+                    floatCache => {
+                        inventory.forEach(item => {
+                            if (result.prices[item.market_hash_name] !== undefined && result.prices[item.market_hash_name] !== 'null'){
+                                item.price =  getPrice(item.market_hash_name, item.dopplerInfo, result.prices, result.pricingProvider, result.exchangeRate, result.currency);
+                            }
+                            if (floatCache[item.assetid] !== undefined && floatCache[item.assetid] !== null && itemTypes[item.type.key].float) {
+                                item.floatInfo = floatCache[item.assetid];
+                                item.patternInfo = getPattern(item.market_hash_name, item.floatInfo.paintSeed);
+                            }
+                        });
+                        sendResponse({addPricesAndFloatsToInventory: inventory});
                     }
-                    if (result.floatCache[item.assetid] !== undefined && itemTypes[item.type.key].float) {
-                        item.floatInfo = result.floatCache[item.assetid].floatInfo;
-                        item.patternInfo = getPattern(item.market_hash_name, item.floatInfo.paintSeed);
-                        floatCacheAssetIDs.push(item.assetid);
-                    }
-                });
-                sendResponse({addPricesToInventory: inventory});
+                );
             }
-            else sendResponse({addPricesToInventory: inventory});
+            else sendResponse({addPricesAndFloatsToInventory: inventory});
         });
         return true;
     }

--- a/extension/chrome/js/background_scripts/messaging.js
+++ b/extension/chrome/js/background_scripts/messaging.js
@@ -260,7 +260,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
             }).then((body) => {
                 if (body.iteminfo.floatvalue !== undefined) {
                     let usefulFloatInfo = extractUsefulFloatInfo(body.iteminfo);
-                    chrome.storage.local.get('floatCache', (result) => {updateFloatCache(result.floatCache, assetID, usefulFloatInfo)});
+                    addToFloatCache(assetID, usefulFloatInfo);
                     if (usefulFloatInfo.floatvalue !== 0) sendResponse({floatInfo: usefulFloatInfo});
                     else sendResponse('nofloat');
                 }

--- a/extension/chrome/js/background_scripts/messaging.js
+++ b/extension/chrome/js/background_scripts/messaging.js
@@ -133,7 +133,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
                     }
                 }
                 sendResponse({inventory: itemsPropertiesToReturn.sort((a, b) => { return a.position - b.position})});
-                updateFloatCache(result.floatCache, floatCacheAssetIDs);
+                updateFloatCache(floatCacheAssetIDs);
             }).catch(err => {
                 console.log(err);
                 sendResponse({inventory: 'error'});

--- a/extension/chrome/js/content_scripts/steam/market_listing.js
+++ b/extension/chrome/js/content_scripts/steam/market_listing.js
@@ -62,7 +62,7 @@ function addListingsToFloatQueue() {
                         });
                     }
                 }
-                updateFloatCache(result.floatCache, floatCacheUsed, null);
+                updateFloatCache(floatCacheUsed);
                 if (!floatQueue.active) workOnFloatQueue();
             }
         }

--- a/extension/chrome/js/content_scripts/steam/market_listing.js
+++ b/extension/chrome/js/content_scripts/steam/market_listing.js
@@ -40,29 +40,22 @@ function addStickers() {
 }
 
 function addListingsToFloatQueue() {
-    chrome.storage.local.get(['autoFloatMarket', 'floatCache'], (result) => {
+    chrome.storage.local.get('autoFloatMarket', (result) => {
         if (result.autoFloatMarket) {
             if (itemWithInspectLink) {
                 let listings = getListings();
-                let floatCacheUsed = [];
                 for (let listing in listings) {
                     listing = listings[listing];
                     let assetID = listing.asset.id;
-                    if (result.floatCache[assetID] !== undefined) {
-                        floatCacheUsed.push(assetID);
-                        populateFloatInfo(listing.listingid, result.floatCache[assetID].floatInfo);
-                        setStickerInfo(listing.listingid, result.floatCache[assetID].floatInfo.stickers);
-                    }
-                    else {
-                        floatQueue.jobs.push({
-                            type: 'market',
-                            assetID: assetID,
-                            inspectLink: listing.asset.actions[0].link.replace('%assetid%', assetID),
-                            listingID: listing.listingid
-                        });
-                    }
+
+                    floatQueue.jobs.push({
+                        type: 'market',
+                        assetID: assetID,
+                        inspectLink: listing.asset.actions[0].link.replace('%assetid%', assetID),
+                        listingID: listing.listingid
+                    });
+
                 }
-                updateFloatCache(floatCacheUsed);
                 if (!floatQueue.active) workOnFloatQueue();
             }
         }

--- a/extension/chrome/js/content_scripts/steam/tradeoffer.js
+++ b/extension/chrome/js/content_scripts/steam/tradeoffer.js
@@ -6,10 +6,10 @@ function getInventories(){
         let yourBuiltInventory = buildInventoryStructure(yourInventory);
         let theirBuiltInventory = buildInventoryStructure(theirInventory);
 
-        chrome.runtime.sendMessage({addPricesToInventory: yourBuiltInventory}, (response) => {
-            let yourInventoryWithPrices = response.addPricesToInventory;
-            chrome.runtime.sendMessage({addPricesToInventory: theirBuiltInventory}, (response) => {
-                let theirInventoryWithPrices = response.addPricesToInventory;
+        chrome.runtime.sendMessage({addPricesAndFloatsToInventory: yourBuiltInventory}, (response) => {
+            let yourInventoryWithPrices = response.addPricesAndFloatsToInventory;
+            chrome.runtime.sendMessage({addPricesAndFloatsToInventory: theirBuiltInventory}, (response) => {
+                let theirInventoryWithPrices = response.addPricesAndFloatsToInventory;
                 for (let assetid in yourInventoryWithPrices) combinedInventories.push(yourInventoryWithPrices[assetid]);
                 for (let assetid in theirInventoryWithPrices) combinedInventories.push(theirInventoryWithPrices[assetid]);
                 addItemInfo();

--- a/extension/chrome/js/utils/enums.js
+++ b/extension/chrome/js/utils/enums.js
@@ -19951,17 +19951,15 @@ const storageKeys = {
     popupLinks: defaultPopupLinks,
     steamIDOfUser: '',
     customCommentsToReport: [],
-    floatCache: {},
     autoFloatMarket: true,
     autoFloatOffer: true,
     autoFloatInventory: true,
     analyticsEvents: [],
     clientID: '',
-    telemetryOn: true,
-    floatCacheKeys: []
+    telemetryOn: true
 };
 
-const nonSettingStorageKeys = ['bookmarks', 'prices', 'exchangeRates', 'floatCache', 'analyticsEvents', 'clientID', 'floatCacheKeys', 'floatCacheContent'];
+const nonSettingStorageKeys = ['bookmarks', 'prices', 'exchangeRates', 'analyticsEvents', 'clientID'];
 
 const commentsToReport = [
     'free skins CS:GO(100$)',

--- a/extension/chrome/js/utils/enums.js
+++ b/extension/chrome/js/utils/enums.js
@@ -19957,10 +19957,11 @@ const storageKeys = {
     autoFloatInventory: true,
     analyticsEvents: [],
     clientID: '',
-    telemetryOn: true
+    telemetryOn: true,
+    floatCacheKeys: []
 };
 
-const nonSettingStorageKeys = ['bookmarks', 'prices', 'exchangeRates', 'floatCache', 'analyticsEvents', 'clientID'];
+const nonSettingStorageKeys = ['bookmarks', 'prices', 'exchangeRates', 'floatCache', 'analyticsEvents', 'clientID', 'floatCacheKeys', 'floatCacheContent'];
 
 const commentsToReport = [
     'free skins CS:GO(100$)',

--- a/extension/chrome/js/utils/utils.js
+++ b/extension/chrome/js/utils/utils.js
@@ -1115,48 +1115,20 @@ function extractUsefulFloatInfo(floatInfo) {
     };
 }
 
-function updateFloatCache(floatCache, assetIDs, floatInfo) {
+function updateFloatCache(assetIDs) {
     assetIDs = arrayFromArrayOrNotArray(assetIDs);
 
     let floatStorageKeys = [];
     assetIDs.forEach( ID => {floatStorageKeys.push(`floatCache_${ID}`)});
-    floatStorageKeys.push('floatCacheKeys');
 
     chrome.storage.local.get([floatStorageKeys], (result) => {
-        assetIDs.forEach((assetID) => {
-            if (result[`floatCache_${assetID}`] === undefined && assetID !== '') { // if not in cache at all, adding it
-                chrome.storage.local.set({[`floatCache_${assetID}`]:
-                        {
-                            floatInfo: floatInfo,
-                            added: Date.now(),
-                            lastUsed: Date.now(),
-                            used: 0
-                        }
-                }, () => {});
-            }
-            else{ // update cache
-                result[`floatCache_${assetID}`].lastUsed = Date.now();
-                result[`floatCache_${assetID}`].used = floatCache[assetID].used + 1;
-            }
-        });
+        for (let floatKey in result) {
+            console.log(floatKey);
+            result[floatKey].lastUsed = Date.now();
+            result[floatKey].used = floatCache[assetID].used + 1;
+            chrome.storage.local.set({[floatKey]: result[floatKey]}, () => {});
+        }
     });
-
-    // assetIDs.forEach((assetID) => {
-    //     if (floatCache[assetID] === undefined && assetID !== '') { // if not in cache at all, adding it
-    //         floatCache[assetID] = {
-    //             floatInfo: floatInfo,
-    //             added: Date.now(),
-    //             lastUsed: Date.now(),
-    //             used: 0
-    //         }
-    //     }
-    //     else{ // update cache
-    //         floatCache[assetID].lastUsed = Date.now();
-    //         floatCache[assetID].used = floatCache[assetID].used + 1;
-    //     }
-    // });
-
-    chrome.storage.local.set({floatCache: floatCache}, ()=>{});
 }
 
 function addToFloatCache(assetID, floatInfo) {
@@ -1277,32 +1249,17 @@ function addPageControlEventListeners(type){
 }
 
 function trimFloatCache() {
-    // chrome.storage.local.get('floatCache', (result) => {
-    //     let floatCache = result.floatCache;
-    //     let newFloatCache = {};
-    //
-    //     for (let assetID in floatCache){
-    //         let timeSinceLastUsed = (Date.now() - floatCache[assetID].lastUsed) / 1000; // in seconds
-    //         let used = floatCache[assetID].used;
-    //
-    //         // if unused and in cache for over a day, or used but not for over a week, then this whole thing negated because the ones that do not fit this wil remain in the cache
-    //         if (!((used === 0 && timeSinceLastUsed > 86400) || (used > 0 && timeSinceLastUsed > 604800))) newFloatCache[assetID] = floatCache[assetID];
-    //     }
-    //     chrome.storage.local.set({floatCache: newFloatCache}, () => {});
-    // });
-
-    chrome.storage.local.get('floatCacheKeys', (result) => {
-        result.floatCacheKeys.forEach(assetID => {
-            chrome.storage.local.get([`floatCache_${assetID}`], (result) => {
-                let timeSinceLastUsed = (Date.now() - result[`floatCache_${assetID}`].lastUsed) / 1000; // in seconds
-                let used = result[`floatCache_${assetID}`].used;
+    chrome.storage.local.get(null, (result) => { // gets all storage
+        for (let storageKey in result)
+            if (storageKey.substring(0, 10) === 'floatCache_') {
+                let timeSinceLastUsed = (Date.now() - result[storageKey].lastUsed) / 1000; // in seconds
+                let used = result[storageKey].used;
 
                 // if unused and in cache for over a day, or used but not for over a week, then this whole thing negated because the ones that do not fit this wil remain in the cache
                 if ((used === 0 && timeSinceLastUsed > 86400) || (used > 0 && timeSinceLastUsed > 604800)) {
-                    chrome.storage.local.remove([`floatCache_${assetID}`], () => {});
+                    chrome.storage.local.remove([storageKey], () => {});
                 }
-            });
-        });
+            }
     });
 }
 

--- a/extension/chrome/js/utils/utils.js
+++ b/extension/chrome/js/utils/utils.js
@@ -1159,6 +1159,17 @@ function updateFloatCache(floatCache, assetIDs, floatInfo) {
     chrome.storage.local.set({floatCache: floatCache}, ()=>{});
 }
 
+function addToFloatCache(assetID, floatInfo) {
+    chrome.storage.local.set({[`floatCache_${assetID}`]:
+            {
+                floatInfo: floatInfo,
+                added: Date.now(),
+                lastUsed: Date.now(),
+                used: 0
+            }
+    }, () => {});
+}
+
 function addFloatIndicator(itemElement, floatInfo){
     if (floatInfo !== null && itemElement.querySelector('div.floatIndicator') === null) {
         itemElement.insertAdjacentHTML('beforeend', `<div class="floatIndicator">${floatInfo.floatvalue.toFixed(4)}</div>`);

--- a/extension/chrome/js/utils/utils.js
+++ b/extension/chrome/js/utils/utils.js
@@ -1201,7 +1201,7 @@ function workOnFloatQueue() {
         floatQueue.active = true;
         let job = floatQueue.jobs.shift();
 
-        chrome.runtime.sendMessage({getFloatInfo: job.inspectLink}, (response) => {
+        chrome.runtime.sendMessage({fetchFloatInfo: job.inspectLink}, (response) => {
             if (response === 'error') {
                 floatQueue.jobs.push(job);
             }
@@ -1281,7 +1281,6 @@ function trimFloatCache() {
     // });
 
     chrome.storage.local.get('floatCacheKeys', (result) => {
-
         result.floatCacheKeys.forEach(assetID => {
             chrome.storage.local.get([`floatCache_${assetID}`], (result) => {
                 let timeSinceLastUsed = (Date.now() - result[`floatCache_${assetID}`].lastUsed) / 1000; // in seconds


### PR DESCRIPTION
Moves float cache from under a single key that always has to be retrieved as a whole and written back into individual, per item keys. The extension was running slower and slower the float cache was becoming bigger and bigger. This change makes float loading less computationally expensive, easier on resources, especially CPU. 